### PR TITLE
fix concurrency related bugs and improve output

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -92,3 +92,4 @@ Need to handle the case when multiple messages arrive at the socket, since we ar
 Handled the case when the first marker is the last marker we are expecting
 Maintaining an Enum Event for all event types.
 lets connect to our own client as well, just to simplify the logic.
+When initiating a new snapshot, the current balance should be recorded immediately, to avoid discrepancy.

--- a/snapshot.py
+++ b/snapshot.py
@@ -34,10 +34,11 @@ class Snapshot:
         output_str_list = []
         output_str_list.append(f"Client id : {self.client_id}")
         output_str_list.append(f"Local state :")
-        output_str_list.append(f"{self.local_state}")
+        output_str_list.append(f"   {self.local_state}")
         output_str_list.append("Channel states :")
-        for client_id, channel_state in self.channel_state_dict.items():
-            output_str_list.append(f"{client_id} : {channel_state}")
+        for client_id in sorted(self.channel_state_dict):
+            channel_state = self.channel_state_dict[client_id]
+            output_str_list.append(f"   {client_id} : {channel_state}")
         return "\n".join(output_str_list) + "\n"
 
 
@@ -52,7 +53,8 @@ class GlobalSnapshot:
     def __repr__(self):
         output_str_list = []
         output_str_list.append(f"Snapshot id : {self.snapshot_id}")
-        for client_id, partial_snapshot in self.partial_snapshots.items():
+        for client_id in sorted(self.partial_snapshots.keys()):
+            partial_snapshot = self.partial_snapshots[client_id]
             output_str_list.append("=====================================================")
             output_str_list.append(f"{partial_snapshot}")
             output_str_list.append("=====================================================")


### PR DESCRIPTION
1. Handle the case when balance during the snapshot initiation process was picking the latest balance instead of the balance that the system had when snapshot was initiated.

2. Logging improve to display the channels / clients in sorted order